### PR TITLE
error code maybe null

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 var exec = require('child_process').exec;
 
 function potentialExit (childCmd, code) {
-    code = code.code || code;
+    code = code? (code.code || code) : code;
     if (code > 0) {
         console.error('`' + childCmd + '` failed with exit code ' + code);
         process.exit(code);


### PR DESCRIPTION
I've come across a case that on Windows machine running a watch parallel with jetty, sometimes it gives code = null, which will fail the script.