### PR TITLE
Tweak to README for Windows users

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,10 @@ To use the command, simply call it with a set of strings - which correspond to
 shell arguments, for example:
 
 ```bash
-parallelshell 'echo 1' 'echo 2' 'echo 3'
+parallelshell "echo 1" "echo 2" "echo 3"
 ```
 
 This will execute the commands `echo 1` `echo 2` and `echo 3` simultaneously.
+
+Note that on Windows, you need to use double-quotes to avoid confusing the
+argument parser.


### PR DESCRIPTION
Ran into an issue on Windows where running `parallelshell 'echo 1'` resulted in:

```
''echo' is not recognized as an internal or external command,
operable program or batch file.
`'echo` failed with exit code 1
```

Running `parallelshell "echo 1"` worked. I'm pretty sure it's just due to how `process.argv` gets populated by Node. It seems to treat single quotes as part of the argument string.