### PR TITLE
Ability to set CWD

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,15 @@ This will execute the commands `echo 1` `echo 2` and `echo 3` simultaneously.
 Note that on Windows, you need to use double-quotes to avoid confusing the
 argument parser.
 
+#### Setting The Current Working Directory (CWD)
+
+To run a command in a specified directory, pass a JSON array with the first element as the CWD and the second element as the command:
+
+```bash
+parallelshell '["/some/folder","some command"]'
+```
+**Note**: Due to how JSON.parse works, string input in the arrays need to be in double quotes.
+
 Available options:
 ```
 -h, --help         output usage information

--- a/index.js
+++ b/index.js
@@ -98,11 +98,20 @@ if (process.platform === 'win32') {
 // start the children
 children = [];
 cmds.forEach(function (cmd) {
+    var cwd = undefined;
+    try {
+        var cmd_tmp = JSON.parse(cmd);
+	if (cmd_tmp.length === 2) {
+        	cwd = cmd_tmp[0];
+        	cmd = cmd_tmp[1];
+	}
+    } catch(SyntaxError) {}; // Squash this error
+
     if (process.platform != 'win32') {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.cwd,
+        cwd: (cwd === undefined) ? process.cwd : cwd,
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })


### PR DESCRIPTION
Hi Keith

Inspired by your blog post about scrapping grunt etc, and just using NPM, I happily using parallelshell. Unfortunately, there are many cases where I need to set the current working directory (CWD) to run the command in. Now that we are using `exec`, `cd` does not work. So I have come up with my own solution, which is to pass parallelshell a JSON array, and if it parses and if it contains two items, the first item will be the CWD. If any of those conditions do not hold, then just use as per normal.