### PR TITLE
Always quit with the correct exit code

### DIFF
--- a/index.js
+++ b/index.js
@@ -42,6 +42,11 @@ function childClose (code) {
             console.log('`' + this.cmd + '` ended successfully');
         }
     }
+    if (code > 0) {
+        process.on('exit', function() {
+            process.exit(code);
+        });
+    }
     if (code > 0 && !wait) close(code);
     status();
 }


### PR DESCRIPTION
Quit with the exit code of the first failing child, even if the other children exit very fast after the failing child.

Output with the current master:
```
$ ./index.js -v true false true ; echo $?
`exec true` ended successfully


### Status ###
`exec true` finished
`exec false` is still running
`exec true` is still running


`exec false` failed with exit code 1
`exec true` will now be closed
`exec true` will now be closed


### Status ###
`exec true` finished
`exec false` errored
`exec true` is still running


0
```

This patch changes the output code to 1. If you have a better solution and/or understanding of the problem, feel free to discard this PR, but the underlying issue is real.