### PR TITLE
Fix BUG: Assign variables throw and error

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,8 @@ function childClose (code) {
 
 function status () {
   if (verbose) {
-    var i, len
+    var i
+    var len
     console.log('\n')
     console.log('### Status ###')
     for (i = 0, len = children.length; i < len; i++) {
@@ -65,7 +66,10 @@ function status () {
 
 // closes all children and the process
 function close (code) {
-  var i, len, closed = 0, opened = 0
+  var i
+  var len
+  var closed = 0
+  var opened = 0
 
   for (i = 0, len = children.length; i < len; i++) {
     if (!children[i].exitCode) {
@@ -104,7 +108,7 @@ cmds.forEach(function (cmd) {
     env: process.env,
     stdio: ['pipe', process.stdout, process.stderr]
   })
-    .on('close', childClose)
+  .on('close', childClose)
   child.cmd = cmd
   children.push(child)
 })

--- a/index.js
+++ b/index.js
@@ -1,113 +1,113 @@
 #!/usr/bin/env node
 
-'use strict';
-var spawn = require('child_process').spawn;
+'use strict'
+var spawn = require('child_process').spawn
 
-var sh, shFlag, children, args, wait, cmds, verbose, i, len;
+var sh, shFlag, children, args, wait, cmds, verbose, i, len
 // parsing argv
-cmds = [];
-args = process.argv.slice(2);
+cmds = []
+args = process.argv.slice(2)
 for (i = 0, len = args.length; i < len; i++) {
-    if (args[i][0] === '-') {
-        switch (args[i]) {
-            case '-w':
-            case '--wait':
-                wait = true;
-                break;
-            case '-v':
-            case '--verbose':
-                verbose = true;
-                break;
-            case '-h':
-            case '--help':
-                console.log('-h, --help         output usage information');
-                console.log('-v, --verbose      verbose logging');
-                console.log('-w, --wait         will not close sibling processes on error');
-                process.exit();
-                break;
-        }
-    } else {
-        cmds.push(args[i]);
+  if (args[i][0] === '-') {
+    switch (args[i]) {
+      case '-w':
+      case '--wait':
+        wait = true
+        break
+      case '-v':
+      case '--verbose':
+        verbose = true
+        break
+      case '-h':
+      case '--help':
+        console.log('-h, --help         output usage information')
+        console.log('-v, --verbose      verbose logging')
+        console.log('-w, --wait         will not close sibling processes on error')
+        process.exit()
+        break
     }
+  } else {
+    cmds.push(args[i])
+  }
 }
 
 // called on close of a child process
 function childClose (code) {
-    code = code ? (code.code || code) : code;
-    if (verbose) {
-        if (code > 0) {
-            console.error('`' + this.cmd + '` failed with exit code ' + code);
-        } else {
-            console.log('`' + this.cmd + '` ended successfully');
-        }
+  code = code ? (code.code || code) : code
+  if (verbose) {
+    if (code > 0) {
+      console.error('`' + this.cmd + '` failed with exit code ' + code)
+    } else {
+      console.log('`' + this.cmd + '` ended successfully')
     }
-    if (code > 0 && !wait) close(code);
-    status();
+  }
+  if (code > 0 && !wait) close(code)
+  status()
 }
 
 function status () {
-    if (verbose) {
-        var i, len;
-        console.log('\n');
-        console.log('### Status ###');
-        for (i = 0, len = children.length; i < len; i++) {
-            if (children[i].exitCode === null) {
-                console.log('`' + children[i].cmd + '` is still running');
-            } else if (children[i].exitCode > 0) {
-                console.log('`' + children[i].cmd + '` errored');
-            } else {
-                console.log('`' + children[i].cmd + '` finished');
-            }
-        }
-        console.log('\n');
+  if (verbose) {
+    var i, len
+    console.log('\n')
+    console.log('### Status ###')
+    for (i = 0, len = children.length; i < len; i++) {
+      if (children[i].exitCode === null) {
+        console.log('`' + children[i].cmd + '` is still running')
+      } else if (children[i].exitCode > 0) {
+        console.log('`' + children[i].cmd + '` errored')
+      } else {
+        console.log('`' + children[i].cmd + '` finished')
+      }
     }
+    console.log('\n')
+  }
 }
 
 // closes all children and the process
 function close (code) {
-    var i, len, closed = 0, opened = 0;
+  var i, len, closed = 0, opened = 0
 
-    for (i = 0, len = children.length; i < len; i++) {
-        if (!children[i].exitCode) {
-            opened++;
-            children[i].removeAllListeners('close');
-            children[i].kill('SIGINT');
-            if (verbose) console.log('`' + children[i].cmd + '` will now be closed');
-            children[i].on('close', function () {
-                closed++;
-                if (opened === closed) {
-                    process.exit(code);
-                }
-            });
+  for (i = 0, len = children.length; i < len; i++) {
+    if (!children[i].exitCode) {
+      opened++
+      children[i].removeAllListeners('close')
+      children[i].kill('SIGINT')
+      if (verbose) console.log('`' + children[i].cmd + '` will now be closed')
+      children[i].on('close', function () {
+        closed++
+        if (opened === closed) {
+          process.exit(code)
         }
+      })
     }
-    if (opened === closed) process.exit(code);
+  }
+  if (opened === closed) process.exit(code)
 }
 
 // cross platform compatibility
 if (process.platform === 'win32') {
-    sh = 'cmd';
-    shFlag = '/c';
+  sh = 'cmd'
+  shFlag = '/c'
 } else {
-    sh = 'sh';
-    shFlag = '-ca';
+  sh = 'sh'
+  shFlag = '-ca'
 }
 
 // start the children
-children = [];
+children = []
 cmds.forEach(function (cmd) {
-    if (process.platform !== 'win32') {
-      cmd = 'exec ' + cmd;
-    }
-    var child = spawn(sh, [shFlag, cmd], {
-        cwd: process.cwd,
-        env: process.env,
-        stdio: ['pipe', process.stdout, process.stderr]
-    })
-    .on('close', childClose);
-    child.cmd = cmd;
-    children.push(child);
-});
+  if (process.platform !== 'win32') {
+    cmd = 'exec ' + cmd
+  }
+  var child = spawn(sh, [shFlag, cmd], {
+    cwd: process.cwd,
+    env: process.env,
+    stdio: ['pipe', process.stdout, process.stderr]
+  })
+    .on('close', childClose)
+  child.cmd = cmd
+  children.push(child)
+})
 
 // close all children on ctrl+c
-process.on('SIGINT', close);
+process.on('SIGINT', close)

--- a/index.js
+++ b/index.js
@@ -94,13 +94,13 @@ if (process.platform === 'win32') {
   shFlag = '/c'
 } else {
   sh = 'sh'
-  shFlag = '-ca'
+  shFlag = '-c'
 }
 
 // start the children
 children = []
 cmds.forEach(function (cmd) {
-  if (process.platform !== 'win32') {
+  if (process.platform !== 'win32' && process.platform !== 'darwin') {
     cmd = 'exec ' + cmd
   }
   var child = spawn(sh, [shFlag, cmd], {

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@
 'use strict';
 var spawn = require('child_process').spawn;
 
-var sh, shFlag, children, args, wait, cmds, verbose, i ,len;
+var sh, shFlag, children, args, wait, cmds, verbose, i, len;
 // parsing argv
 cmds = [];
 args = process.argv.slice(2);
@@ -21,8 +21,8 @@ for (i = 0, len = args.length; i < len; i++) {
             case '-h':
             case '--help':
                 console.log('-h, --help         output usage information');
-                console.log('-v, --verbose      verbose logging')
-                console.log('-w, --wait         will not close sibling processes on error')
+                console.log('-v, --verbose      verbose logging');
+                console.log('-w, --wait         will not close sibling processes on error');
                 process.exit();
                 break;
         }
@@ -33,7 +33,6 @@ for (i = 0, len = args.length; i < len; i++) {
 
 // called on close of a child process
 function childClose (code) {
-    var i, len;
     code = code ? (code.code || code) : code;
     if (verbose) {
         if (code > 0) {
@@ -72,18 +71,17 @@ function close (code) {
         if (!children[i].exitCode) {
             opened++;
             children[i].removeAllListeners('close');
-            children[i].kill("SIGINT");
+            children[i].kill('SIGINT');
             if (verbose) console.log('`' + children[i].cmd + '` will now be closed');
-            children[i].on('close', function() {
+            children[i].on('close', function () {
                 closed++;
-                if (opened == closed) {
+                if (opened === closed) {
                     process.exit(code);
                 }
             });
         }
     }
-    if (opened == closed) {process.exit(code);}
-
+    if (opened === closed) process.exit(code);
 }
 
 // cross platform compatibility
@@ -92,24 +90,24 @@ if (process.platform === 'win32') {
     shFlag = '/c';
 } else {
     sh = 'sh';
-    shFlag = '-c';
+    shFlag = '-ca';
 }
 
 // start the children
 children = [];
 cmds.forEach(function (cmd) {
-    if (process.platform != 'win32') {
-      cmd = "exec "+cmd;
+    if (process.platform !== 'win32') {
+      cmd = 'exec ' + cmd;
     }
-    var child = spawn(sh,[shFlag,cmd], {
+    var child = spawn(sh, [shFlag, cmd], {
         cwd: process.cwd,
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })
     .on('close', childClose);
-    child.cmd = cmd
-    children.push(child)
+    child.cmd = cmd;
+    children.push(child);
 });
 
 // close all children on ctrl+c
-process.on('SIGINT', close)
+process.on('SIGINT', close);


### PR DESCRIPTION
Hello @keithamus,

As I comment on the Issue https://github.com/keithamus/parallelshell/issues/45, parallelshell can't assign a variable on a command that execute.

I didn't know why, but I found a real use case without any work-arround.

Reading a little bit the `sh -c`'s documentation, I found that you can use `-a` for make variables to export. But isn't exactly what I want, but still adds the possibility of export a variable with parallelshell.
TODO: Check if Linux/Windows is working fine.

and then I figure it out, that the condition of add 'exec' on the commands it's only for non window platforms, just added mac and works fine the assignment.

I fixed also: 
- Fix some === eq
- Remove some not used vars
- Use standardjs (as I see that the tests are in coffee, make sense don't have semicolons)

So... the only 'line of code` of this PR is: https://github.com/keithamus/parallelshell/compare/master...davesnx:Issue45?expand=1#diff-168726dbe96b3ce427e7fedce31bb0bcR103