### PR TITLE
cwd is a function, not a string

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ cmds.forEach(function (cmd) {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.cwd,
+        cwd: process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -32,7 +32,7 @@ cmdWrapper = (cmd) ->
 
 spawnParallelshell = (cmd) ->
   return spawn sh, [shArg, cmdWrapper("node ./index.js "+cmd )], {
-    cwd: process.cwd
+    cwd: process.cwd()
   }
 
 killPs = (ps) ->


### PR DESCRIPTION
I was looking through the source code, and saw what I believe are some typos! Not sure though. I'm guessing this has been working because perhaps internally the cwd argument is discarded if not a real path, such as `[Function: cwd]`.
