### PR TITLE
Allow the current working directory to be configured per command

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ parallelshell "echo 1" "echo 2" "echo 3"
 
 This will execute the commands `echo 1` `echo 2` and `echo 3` simultaneously.
 
+You can also specify the working directory of each command individually by
+prefixing the command with `CWD=path/to/directory`. For example:
+
+```bash
+parallelshell "echo 1" "CWD=/tmp/ echo $PWD" "CWD=/etc/ echo $PWD"
+```
+
+`CWD=` must be at the beginning of the command string.
+
 Note that on Windows, you need to use double-quotes to avoid confusing the
 argument parser.
 

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ cmds.forEach(function (cmd) {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.cwd,
+        cwd: process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })

--- a/index.js
+++ b/index.js
@@ -98,11 +98,18 @@ if (process.platform === 'win32') {
 // start the children
 children = [];
 cmds.forEach(function (cmd) {
+    var reCWD = /^CWD=([^\s]+)/;
+    var cwd = reCWD.exec(cmd);
+
+    if (cwd) {
+        cmd = cmd.replace(cwd[0], '');
+    }
+
     if (process.platform != 'win32') {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: process.cwd(),
+        cwd: (cwd && cwd[1]) || process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -1,3 +1,4 @@
+path = require "path"
 chai = require "chai"
 should = chai.should()
 spawn = require("child_process").spawn
@@ -16,6 +17,7 @@ else
 # children
 waitingProcess = "\"node -e 'setTimeout(function(){},10000);'\""
 failingProcess = "\"node -e 'throw new Error();'\""
+cwdProcess = "\"CWD=test node -p 'process.cwd();'\"";
 
 usageInfo = """
 -h, --help         output usage information
@@ -59,7 +61,8 @@ testOutput = (cmd, expectedOutput) ->
       output = output.concat(lines)
     ps.stdout.on "end", () ->
       for line,i in expectedOutput
-        line.should.equal output[i]
+        should.exist output[i]
+        output[i].should.equal line
       resolve()
 
 describe "parallelshell", ->
@@ -117,3 +120,8 @@ describe "parallelshell", ->
       ps.signalCode.should.equal "SIGINT"
       done()
     killPs(ps)
+
+  it "should allow setting the cwd via the command", (done) ->
+    testOutput(cwdProcess, [path.join(process.cwd(), "test")])
+    .then -> done()
+    .catch done

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -32,7 +32,7 @@ cmdWrapper = (cmd) ->
 
 spawnParallelshell = (cmd) ->
   return spawn sh, [shArg, cmdWrapper("node ./index.js "+cmd )], {
-    cwd: process.cwd
+    cwd: process.cwd()
   }
 
 killPs = (ps) ->


### PR DESCRIPTION
I wanted the ability to configure where the command would execute, and since parallelshell uses `sh` and `exec` only one command is allowed (e.g. prefixing the command with `cd dir/thing` won't work because there is no shell).

Hopefully this is ok! Tests pass, and I added documentation.
