### PR TITLE
Fixed TypeError for nodejs > 8

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ cmds.forEach(function (cmd) {
       cmd = "exec "+cmd;
     }
     var child = spawn(sh,[shFlag,cmd], {
-        cwd: checkNodeVersion('8.0.0', process.versions.node) ? process.cwd() : process.cwd,
+        cwd: parseInt(process.versions.node) < 8 ? process.cwd : process.cwd(),
         env: process.env,
         stdio: ['pipe', process.stdout, process.stderr]
     })


### PR DESCRIPTION
Some errors are thrown when trying to use this package with Node v10.15.0
throw new ERR_INVALID_ARG_TYPE('options.cwd', 'string', options.cwd)
TypeError [ERR_INVALID_ARG_TYPE]: The "options.cwd" property must be of type string